### PR TITLE
Update Services.yml

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -8,6 +8,6 @@ services:
 #        arguments: [@service_id, "plain_value", %parameter%]
     zurb_ink.inlinecss.twig:
         class: %zurb_ink.inlinecss.twig.class%
-        arguments: [@zurb_ink.inlinecss, @file_locator]
+        arguments: ["@zurb_ink.inlinecss", "@file_locator"]
         tags:
             - { name: twig.extension }


### PR DESCRIPTION
For Symfony3+ you get the following error when trying to install the bundle

  [Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]
  The file "vendor/hampe/zurb-ink-bundle/Hampe/Bundle/ZurbInkBundle/Dependency
  Injection/../Resources/config/services.yml" does not contain valid YAML.


  [Symfony\Component\Yaml\Exception\ParseException]
  The reserved indicator "@" cannot start a plain scalar; you need to quote t
  he scalar at line 10 (near "arguments: [@zurb_ink.inlinecss, @file_locator]
  ").


All arguments in all configuration files need to be quoted in Symfony 3+ doing so fixes these errors.