### PR TITLE
Fix Deprecation Warning

### DIFF
--- a/Twig/InlineCssExtension.php
+++ b/Twig/InlineCssExtension.php
@@ -10,10 +10,11 @@ namespace Hampe\Bundle\ZurbInkBundle\Twig;
 
 use Hampe\Bundle\ZurbInkBundle\Service\CssContainer;
 use \Twig_Extension;
+use \Twig_Extension_GlobalsInterface;
 use \Twig_SimpleFunction;
 use \PhpCollection\Sequence;
 
-class InlineCssExtension extends Twig_Extension
+class InlineCssExtension extends Twig_Extension implements Twig_Extension_GlobalsInterface
 {
 
     protected $inlineCss;

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php":                      ">=5.3.2",
         "symfony/framework-bundle": ">=2.0.0",
+        "twig/twig":                ">=1.23.0",
         "tijsverkoyen/css-to-inline-styles": "1.*"
     },
     "autoload": {


### PR DESCRIPTION
Twig version 1.23.0 [deprecated](https://github.com/twigphp/Twig/blob/1.x/CHANGELOG#L13) the `Twig_ExtensionInterface::getGlobals()` method. A warning is now thrown if an extension does not explicitly implement the `Twig_Extension_GlobalsInterface`.