### PR TITLE
Fix deprecation notice when using Twig 1.26

### DIFF
--- a/Twig/InkyNode.php
+++ b/Twig/InkyNode.php
@@ -11,19 +11,17 @@
  *  @date       16.04.16
  */ 
 
-
 namespace Hampe\Bundle\ZurbInkBundle\Twig;
-
 
 use Twig_Node;
 
 class InkyNode extends Twig_Node
 {
-
     public function __construct(\Twig_Node $body, $lineno, $tag = 'inky')
     {
         parent::__construct(array('body' => $body), array(), $lineno, $tag);
     }
+
     /**
      * Compiles the node to PHP.
      *
@@ -31,12 +29,14 @@ class InkyNode extends Twig_Node
      */
     public function compile(\Twig_Compiler $compiler)
     {
+        $extensionName = (version_compare(\Twig_Environment::VERSION, '1.26.0') >= 0) ? 'Hampe\Bundle\ZurbInkBundle\Twig\InkyExtension' : InkyExtension::NAME;
+
         $compiler
             ->addDebugInfo($this)
             ->write('ob_start();' . PHP_EOL)
             ->subcompile($this->getNode('body'))
             ->write('$inkyHtml = ob_get_clean();' . PHP_EOL)
-            ->write('echo $this->env->getExtension(\'zurb_ink.inky\')->parse($inkyHtml);' . PHP_EOL);
+            ->write("echo \$this->env->getExtension('{$extensionName}')->parse(\$inkyHtml);" . PHP_EOL);
     }
 
 }

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
         }
     ],
     "require": {
-        "php":                      ">=5.3.2",
-        "symfony/framework-bundle": ">=2.0.0",
-        "twig/twig":                ">=1.23.0",
-        "tijsverkoyen/css-to-inline-styles": "1.*",
-        "hampe/inky": ">=1.3.6"
+        "php": "^5.3.2 || ^7.0",
+        "symfony/framework-bundle": "^2.0.0 || ^3.0.0",
+        "twig/twig": "^1.23.0",
+        "tijsverkoyen/css-to-inline-styles": "^1.0",
+        "hampe/inky": "^1.3.6"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Twig 1.26 deprecates getting an extension by its name and requires getting them by their FQCN. To avoid bumping the twig dependency to 1.26, this adds a compile-time check for the twig version to decide which string to use when fetching an extension.

In addition to that change, this PR introduces the SemVer operator in composer.json to avoid unbound version constraints.
