### PR TITLE
Remove version field from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name":        "hampe/zurb-ink-bundle",
     "type":        "symfony-bundle",
-    "version":     "2.2.1.1",
     "description": "Creating email templates is hard. This Bundle provides help.",
     "keywords":    ["email", "zurb", "ink", "template"],
     "homepage":    "http://github.com/thampe/ZurbInkBundle",


### PR DESCRIPTION
Fixes #20.

The recommendation in composer is to omit the version field if it can be inferred from VCS (quote from [documentation](https://getcomposer.org/doc/04-schema.md#version)):
> Note: Packagist uses VCS repositories, so the statement above is very much true for Packagist as well. Specifying the version yourself will most likely end up creating problems at some point due to human error.

It also specifies that the version must follow the format of `X.Y.Z` or `vX.Y.Z`. Since the `composer.json` file in 2.2.1.1 contained a version string of `2.2.1.0`, this version was not picked up by packagist and can't be installed.

Thus, I recommend the following:
* Omit the `version` field from the pull request
* Adopt [Semantic Versioning](http://semver.org/) which is what composer suggests
* Tag a new release, either `2.3.0` or `2.2.1`