### PR TITLE
Fix: Inlining CSS into HTML

### DIFF
--- a/Resources/views/FoundationForEmails/2/base.html.twig
+++ b/Resources/views/FoundationForEmails/2/base.html.twig
@@ -1,5 +1,4 @@
 {% spaceless %}
-{{ zurb_ink_styles.add("@HampeZurbInkBundle/Resources/public/css/foundation-for-emails/2/foundation.min.css") }}
 {% block preHtml %}{% endblock %}
 {% inlinestyle %}
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
@@ -10,6 +9,7 @@
     {% block headStyles %}
         <style type="text/css">
             {% autoescape false %}
+            {{ includeStyles(["@HampeZurbInkBundle/Resources/public/css/foundation-for-emails/2/foundation.min.css"]) }}
             {{ includeStyles(zurb_ink_styles) }}
             {% block additionalStyles %}{% endblock %}
             {% endautoescape %}


### PR DESCRIPTION
#### What ?
Css inlining for the styles included using
```twig 
{{ zurb_ink_styles.add("@YourBundle/Resources/public/css/style1.css") }}
```
doesn't actually inline it, but just include in the styles tag which doesn't work in emails as it requires inlining of these styles.

#### Solution
As described in the readme, foundation css doesn't need inlining hence we shouldn't do `zurb_ink_styles.add` for foundation's css coz that'll try to inline it & fail.

Now i'm using `includeStyles` function directly to render it's styles & not save it in zurb_ink_styles variable.


#### Issue reference
https://github.com/thampe/ZurbInkBundle/issues/25